### PR TITLE
Revert "Build(deps): bump actions/cache from v2 to v2.1.4"

### DIFF
--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2.1.4
+      - uses: actions/cache@v2
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}


### PR DESCRIPTION
Reverts Segelzwerg/FamilyFoto#187

See https://github.com/actions/cache/issues/528#issuecomment-774171032