### PR TITLE
Temporary fix for arm64 docker builds

### DIFF
--- a/arm64.dockerfile
+++ b/arm64.dockerfile
@@ -3,9 +3,8 @@ FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
 FROM arm64v8/python:3.9-bullseye
 COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
 COPY ./requirements.txt requirements.txt
-RUN uname -a
-RUN apt-get update -qq
-RUN apt-get install build-essential ffmpeg -yq
+RUN apt-get update
+RUN apt-get install ffmpeg
 RUN pip install --default-timeout=1000 -r requirements.txt
 WORKDIR /app
 ENV FLASK_APP family_foto

--- a/arm64.dockerfile
+++ b/arm64.dockerfile
@@ -1,6 +1,6 @@
 FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
 
-FROM arm64v8/python:3.9-bullseye
+FROM arm64v8/python:3.9-buster
 COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
 COPY ./requirements.txt requirements.txt
 RUN apt-get update

--- a/arm64.dockerfile
+++ b/arm64.dockerfile
@@ -4,7 +4,7 @@ FROM arm64v8/python:3.9-bullseye
 COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
 COPY ./requirements.txt requirements.txt
 RUN apt-get update
-RUN apt-get install ffmpeg
+RUN apt-get install ffmpeg -y
 RUN pip install --default-timeout=1000 -r requirements.txt
 WORKDIR /app
 ENV FLASK_APP family_foto

--- a/arm64.dockerfile
+++ b/arm64.dockerfile
@@ -1,6 +1,6 @@
 FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
 
-FROM arm64v8/python:3.9-slim
+FROM arm64v8/python:3.9-buster
 COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
 COPY ./requirements.txt requirements.txt
 RUN uname -a

--- a/arm64.dockerfile
+++ b/arm64.dockerfile
@@ -1,6 +1,6 @@
 FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
 
-FROM arm64v8/python:3.9-buster
+FROM arm64v8/python:3.9-bullseye
 COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
 COPY ./requirements.txt requirements.txt
 RUN uname -a


### PR DESCRIPTION
I'm not entirely sure if this will fix it as it still use ffmpeg 7:4.1. and it seems to start failing with ffmpeg 7:4.3.